### PR TITLE
Updated formatter.html.twig

### DIFF
--- a/Resources/views/Form/formatter.html.twig
+++ b/Resources/views/Form/formatter.html.twig
@@ -76,7 +76,7 @@
                         });
                         break;
                     case 'richhtml':
-                        {{ form.children[source_field].vars.id }}_rich_instance = {{ ckeditor_replace(form.children[source_field].vars.id, ckeditor_configuration) }};
+                        {{ form.children[source_field].vars.id }}_rich_instance = {{ ckeditor_widget(form.children[source_field].vars.id, ckeditor_configuration) }};
                 }
             });
 


### PR DESCRIPTION
The latest egeloen/ckeditor bundle 4.4.7 now have new method ckeditor_widget() as replacement of the old ckeditor_replace()
